### PR TITLE
prevent compilers pinned down to specific version

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -47,6 +47,7 @@ ls -larth config/
 
 ./install.sh "${PREFIX}"
 cp -f bin/* "${PREFIX}/nim/bin/"
+mkdir -p "${PREFIX}/bin"
 for binary in "${PREFIX}/nim/bin/"* ; do
   ln -s "${binary}" "${PREFIX}/bin/"
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-gh-15042--Increase-buffer-size-for-readlink-to-1024.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:
@@ -22,11 +22,9 @@ requirements:
     - {{ compiler('cxx') }}
     - rsync
   host:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
   run:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
+    - {{ c_compiler }}_{{ target_platform }}
+    - {{ cxx_compiler }}_{{ target_platform }}
     # used by nimble
     - openssl >=1.1
     # used by nimgrep


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

The current `nim` packages require the very specific versions of the C/C++ compilers than were available when they were built.
That is an unnecessarily strict requirement and is fixed with this PR.